### PR TITLE
Enable back GPU hardware acceleration for Chrome

### DIFF
--- a/src/test/java/com/aerokube/selenoid/misc/WebDriverRule.java
+++ b/src/test/java/com/aerokube/selenoid/misc/WebDriverRule.java
@@ -64,7 +64,6 @@ public class WebDriverRule implements TestRule {
             case CHROME:
                 ChromeOptions chromeOptions = new ChromeOptions();
                 chromeOptions.addArguments("no-sandbox");
-                chromeOptions.addArguments("disable-gpu");
                 chromeOptions.setCapability("screenResolution", "1280x1024x24");
                 return chromeOptions;
             case YANDEX:


### PR DESCRIPTION
Following Chrome 93 Stable release, tests are no longer failing due to GPU crashes.
This reverts #13 